### PR TITLE
Fix leaking unclosed InputStream in TransformerClassWriter

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/TransformerClassWriter.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformerClassWriter.java
@@ -63,6 +63,7 @@ class TransformerClassWriter extends ClassWriter {
             resource = classTransformer.getTransformingClassLoader().getResourceAsStream(target);
             final ClassReader classReader = new ClassReader(resource);
             classReader.accept(new SuperCollectingVisitor(classTransformer), ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+            resource.close();
         } catch (IOException e) {
             LOGGER.fatal("Class {} unable to find resource {}", className, resource);
             throw new RuntimeException("Failed to load hierarchy member " + className, e);


### PR DESCRIPTION
While ASM `ClassReader` takes an `InputStream` as a constructor argument, it doesn't actually close the input stream.

As modlauncher doesn't close the input stream, this causes Forge to leave many thousands of open files, and on some systems even running into the limit of open files (this doesn't appear to be an issue in newer versions of java, where these files end up being closed anyway). Running into limit of closed files also doesn't appear to be reported in any useful way, and the class just fails to load for no apparent reason (just couldn't find the file), but I don't see any way to fix that because java eats the exception and returns null.

There will also be a corresponding PR into forge, ad it has a similar issue.

I don't have much evidence for it, and it's probably just a coincidence, but on my system it also appears to fix JVM crashes that cpw and a few other people have been experiencing on linux.