### PR TITLE
Add some tweaks to improve transformation time

### DIFF
--- a/src/api/java/cpw/mods/modlauncher/serviceapi/ILaunchPluginService.java
+++ b/src/api/java/cpw/mods/modlauncher/serviceapi/ILaunchPluginService.java
@@ -39,7 +39,7 @@ public interface ILaunchPluginService {
      *
      * @param classNode the classnode to process
      * @param classType the name of the class
-     * @return the processed classnode
+     * @return the processed classnode, or null if the class node did not change
      */
     ClassNode processClass(ClassNode classNode, final Type classType);
 

--- a/src/main/java/cpw/mods/modlauncher/LaunchPluginHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/LaunchPluginHandler.java
@@ -31,13 +31,22 @@ public class LaunchPluginHandler {
                 collect(ArrayList<String>::new, (l,e) -> l.add(e.getKey()), ArrayList::addAll);
     }
 
+    /**
+     * @return The classnode with the changes, or null if no changes occured
+     */
+    @Nullable
     public ClassNode offerClassNodeToPlugins(final List<String> pluginNames, @Nullable final ClassNode node, final Type className) {
         ClassNode intermediate = node;
+        boolean transformed = false;
         for (String plugin: pluginNames) {
             final ILaunchPluginService iLaunchPluginService = plugins.get(plugin);
             LOGGER.debug(LAUNCHPLUGIN,"LauncherPluginService {} transforming {}", plugin, className);
-            intermediate = iLaunchPluginService.processClass(intermediate, className);
+            ClassNode afterPlugin = iLaunchPluginService.processClass(intermediate, className);
+            if (afterPlugin != null) { //Code returned a class node - assume it changed
+                intermediate = afterPlugin;
+                transformed = true;
+            }
         }
-        return intermediate;
+        return transformed ? intermediate : null;
     }
 }

--- a/src/main/java/cpw/mods/modlauncher/LogMarkers.java
+++ b/src/main/java/cpw/mods/modlauncher/LogMarkers.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.*;
 
 class LogMarkers {
     static final Marker MODLAUNCHER = MarkerManager.getMarker("MODLAUNCHER");
+    static final Marker TRANSFORMMING = MarkerManager.getMarker("TRANSFORMING").addParents(MODLAUNCHER);
     static final Marker CLASSLOADING = MarkerManager.getMarker("CLASSLOADING").addParents(MODLAUNCHER);
     static final Marker LAUNCHPLUGIN = MarkerManager.getMarker("LAUNCHPLUGIN").addParents(MODLAUNCHER);
 }

--- a/src/main/java/cpw/mods/modlauncher/TransformStore.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformStore.java
@@ -14,7 +14,7 @@ import static cpw.mods.modlauncher.LogMarkers.*;
  */
 public class TransformStore {
     private static final Logger LOGGER = LogManager.getLogger();
-    private final Set<TransformTargetLabel> classNeedsTransforming = new HashSet<>();
+    private final Set<String> classNeedsTransforming = new HashSet<>();
     private final EnumMap<TransformTargetLabel.LabelType, TransformList<?>> transformers;
 
     public TransformStore() {
@@ -45,12 +45,12 @@ public class TransformStore {
     @SuppressWarnings("unchecked")
     <T> void addTransformer(TransformTargetLabel targetLabel, ITransformer<T> transformer) {
         LOGGER.debug(MODLAUNCHER,"Adding transformer {} to {}", () -> transformer, () -> targetLabel);
-        classNeedsTransforming.add(new TransformTargetLabel(targetLabel.getClassName().getInternalName()));
+        classNeedsTransforming.add(targetLabel.getClassName().getInternalName());
         final TransformList<T> transformList = (TransformList<T>) this.transformers.get(targetLabel.getLabelType());
         transformList.addTransformer(targetLabel, transformer);
     }
 
     boolean needsTransforming(String className) {
-        return classNeedsTransforming.contains(new TransformTargetLabel(className));
+        return classNeedsTransforming.contains(className);
     }
 }


### PR DESCRIPTION
Add some additional checks so the classwriter is not used if possible, as classwriting with computing frames can take some time, and avoiding creating a new arraylist if no transformers are present.
Nearly cuts the time spend on transforming classes in half with some changes to forge to return a null ClassNode when nothing is transformed (About 1.5 seconds total to 2.8 spend on ClassTransformer#transform).