### PR TITLE
Make TCL own its classes

### DIFF
--- a/src/test/java/cpw/mods/modlauncher/test/LauncherTests.java
+++ b/src/test/java/cpw/mods/modlauncher/test/LauncherTests.java
@@ -8,6 +8,8 @@ import org.powermock.reflect.*;
 
 import java.io.*;
 import java.lang.reflect.*;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.*;
 
@@ -18,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class LauncherTests {
     @Test
-    void testLauncher() throws IllegalAccessException {
+    void testLauncher() throws Exception {
         final List<String> testJars = Stream.of(System.getProperty("java.class.path").split(File.pathSeparator)).filter(s -> s.contains("testJars")).collect(Collectors.toList());
         String testJarPath = testJars.get(0);
         Launcher.main("--version", "1.0", "--minecraftJar", testJarPath, "--launchTarget", "mockLaunch", "--test.mods", "A,B,C,cpw.mods.modlauncher.testjar.TestClass", "--accessToken", "SUPERSECRET!");
@@ -54,8 +56,22 @@ class LauncherTests {
             assertTrue(transformedFields.anyMatch(f -> f.getName().equals("testfield")), "Found transformed field");
             final Stream<Field> untransformedFields = Stream.of(Class.forName("cpw.mods.modlauncher.testjar.TestClass", true, this.getClass().getClassLoader()).getDeclaredFields());
             assertTrue(untransformedFields.noneMatch(f -> f.getName().equals("testfield")), "Didn't find transformed field");
+
+            Class<?> resClass = Class.forName("cpw.mods.modlauncher.testjar.ResourceLoadingClass", true, Whitebox.getInternalState(Launcher.INSTANCE, "classLoader"));
+            assertFindResource(resClass);
         } catch (ClassNotFoundException e) {
             fail("Can't load class");
+        }
+    }
+
+    private void assertFindResource(Class<?> loaded) throws Exception {
+        Object instance = loaded.getDeclaredConstructor().newInstance();
+        URL resource = (URL) Whitebox.getField(loaded, "resource").get(instance);
+        assertNotNull(resource, "Resource not found");
+        // assert that we can find something in the resource, so we know it loaded properly
+        try (InputStream in = resource.openStream();
+             Scanner scanner = new Scanner(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+            assertTrue(scanner.nextLine().contains("Loaded successfully!"), "Resource has incorrect content");
         }
     }
 }

--- a/src/testJars/java/cpw/mods/modlauncher/testjar/ResourceLoadingClass.java
+++ b/src/testJars/java/cpw/mods/modlauncher/testjar/ResourceLoadingClass.java
@@ -1,0 +1,9 @@
+package cpw.mods.modlauncher.testjar;
+
+import java.net.URL;
+
+public class ResourceLoadingClass {
+
+    public final URL resource = getClass().getResource("ResourceLoadingFile");
+
+}

--- a/src/testJars/resources/cpw/mods/modlauncher/testjar/ResourceLoadingFile
+++ b/src/testJars/resources/cpw/mods/modlauncher/testjar/ResourceLoadingFile
@@ -1,0 +1,1 @@
+Loaded successfully!


### PR DESCRIPTION
This change makes the TransformingClassLoader own the classes that it
loads. This allows Class#loadResource to work properly, because it
will pass the resource through TCL's special resource handling, rather
than to the delegate loader, which won't find anything defined using
the classBytesFinder.

This solves an issue WorldEdit is having with Forge and being unable to reference resources from its own JAR. We're unable to use resource packs due to being cross-platform, and the standard ClassLoading mechanism has proven reliable for handling our use case. Thus, this adapts the TCL to perform more like a standard ClassLoader.