### PR TITLE
Fixed TransformationServicesHandler.alternate nested Optionals

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
@@ -49,7 +49,7 @@ class TransformationServicesHandler {
     private static <I, R> Function<I,Optional<R>> alternate(@Nullable Function<I, Optional<R>> first, @Nullable Function<I, Optional<R>> second) {
         if (second == null) return first;
         if (first == null) return second;
-        return input -> Optional.ofNullable(first.apply(input)).orElseGet(() -> Optional.ofNullable(second.apply(input)).orElse(Optional.empty()));
+        return input -> Optional.ofNullable(first.apply(input).orElseGet(() -> second.apply(input).orElse(null)));
     }
 
     void initializeTransformationServices(ArgumentHandler argumentHandler, Environment environment, final NameMappingServiceHandler nameMappingServiceHandler) {


### PR DESCRIPTION
This fixes `TransformationServicesHandler.alternate` no using the `second` function if both are nonnull.

Before the first `Optional.ofNullable()` would return an `Optional<Optional<R>>` and as it's an optional, it should not be null and thus the `orElseGet()` will always return the value of the `first` function as an Optional and never the value from the supplier using the `second` function.
Optional doesn't check if there is any nested optional and that they are empty, they only check if the value is `null` or not.

@cpw This is a probably the fix to the current issue in #31 not calling the `name -> URL` resolver.