### PR TITLE
Allow LaunchPlugins to specify the required class writing flags

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
+++ b/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
@@ -66,7 +66,7 @@ public class ClassTransformer {
             return inputClass;
         }
 
-        ClassNode clazz = new ClassNode(Opcodes.ASM7);
+        ClassNode clazz = new ClassNode(TransformerClassWriter.ASM_VERSION);
         Supplier<byte[]> digest;
         boolean empty;
         if (inputClass.length > 0) {
@@ -118,11 +118,7 @@ public class ClassTransformer {
         }
         //Transformers always get compute_frames
         int finalFlags = needsTransforming ? ILaunchPluginService.ComputeFlags.COMPUTE_FRAMES : (postFlags | preFlags);
-        finalFlags &= ~ILaunchPluginService.ComputeFlags.SIMPLE_REWRITE; //Strip any modlauncher-custom fields
-
-        //Only use the TransformerClassWriter when needed as it's slower, and only COMPUTE_FRAMES calls getCommonSuperClass
-        boolean requireFrames = (finalFlags & ILaunchPluginService.ComputeFlags.COMPUTE_FRAMES) == ILaunchPluginService.ComputeFlags.COMPUTE_FRAMES;
-        ClassWriter cw = requireFrames ? new TransformerClassWriter(this, clazz) : new ClassWriter(finalFlags | Opcodes.ASM7);
+        ClassWriter cw = TransformerClassWriter.createClassWriter(finalFlags, this, clazz);
         clazz.accept(cw);
         if (MarkerManager.exists("CLASSDUMP") && LOGGER.isEnabled(Level.TRACE) && LOGGER.isEnabled(Level.TRACE, MarkerManager.getMarker("CLASSDUMP"))) {
             dumpClass(cw.toByteArray(), className);

--- a/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
+++ b/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
@@ -83,8 +83,8 @@ public class ClassTransformer {
         }
         auditTrail.addReason(classDesc.getClassName(), reason);
 
-        boolean preresult = pluginHandler.offerClassNodeToPlugins(ILaunchPluginService.Phase.BEFORE, launchPluginTransformerSet.getOrDefault(ILaunchPluginService.Phase.BEFORE, Collections.emptyList()), clazz, classDesc, auditTrail, reason);
-        if (!preresult && !needsTransforming && launchPluginTransformerSet.getOrDefault(ILaunchPluginService.Phase.AFTER, Collections.emptyList()).isEmpty()) {
+        ILaunchPluginService.ComputeLevel preLevel = pluginHandler.offerClassNodeToPlugins(ILaunchPluginService.Phase.BEFORE, launchPluginTransformerSet.getOrDefault(ILaunchPluginService.Phase.BEFORE, Collections.emptyList()), clazz, classDesc, auditTrail, reason);
+        if (preLevel == ILaunchPluginService.ComputeLevel.NO_REWRITE && !needsTransforming && launchPluginTransformerSet.getOrDefault(ILaunchPluginService.Phase.AFTER, Collections.emptyList()).isEmpty()) {
             // Shortcut if there's no further work to do
             return inputClass;
         }
@@ -112,12 +112,15 @@ public class ClassTransformer {
             clazz = this.performVote(classTransformers, clazz, context);
         }
 
-        boolean postresult = pluginHandler.offerClassNodeToPlugins(ILaunchPluginService.Phase.AFTER, launchPluginTransformerSet.getOrDefault(ILaunchPluginService.Phase.AFTER, Collections.emptyList()), clazz, classDesc, auditTrail, reason);
-        if (!preresult && !postresult && !needsTransforming) {
+        ILaunchPluginService.ComputeLevel postLevel = pluginHandler.offerClassNodeToPlugins(ILaunchPluginService.Phase.AFTER, launchPluginTransformerSet.getOrDefault(ILaunchPluginService.Phase.AFTER, Collections.emptyList()), clazz, classDesc, auditTrail, reason);
+        if (preLevel == ILaunchPluginService.ComputeLevel.NO_REWRITE && postLevel == ILaunchPluginService.ComputeLevel.NO_REWRITE && !needsTransforming) {
             return inputClass;
         }
+        //Transformers always get compute_frames
+        ILaunchPluginService.ComputeLevel finalLevel = needsTransforming ? ILaunchPluginService.ComputeLevel.COMPUTE_FRAMES : postLevel.mergeWith(preLevel);
 
-        ClassWriter cw = new TransformerClassWriter(this, clazz);
+        //Only use the TransformerClassWriter when needed as it's slower, and only COMPUTE_FRAMES calls getCommonSuperClass
+        ClassWriter cw = finalLevel == ILaunchPluginService.ComputeLevel.COMPUTE_FRAMES ? new TransformerClassWriter(this, clazz) : new ClassWriter(finalLevel.getFlag() | Opcodes.ASM7);
         clazz.accept(cw);
         if (MarkerManager.exists("CLASSDUMP") && LOGGER.isEnabled(Level.TRACE) && LOGGER.isEnabled(Level.TRACE, MarkerManager.getMarker("CLASSDUMP"))) {
             dumpClass(cw.toByteArray(), className);
@@ -166,7 +169,7 @@ public class ClassTransformer {
             if (results.containsKey(TransformerVoteResult.YES)) {
                 final ITransformer<T> transformer = results.get(TransformerVoteResult.YES).get(0).getTransformer();
                 node = transformer.transform(node, context);
-                auditTrail.addTransformerAuditTrail(context.getClassName(), ((TransformerHolder)transformer).owner(), transformer);
+                auditTrail.addTransformerAuditTrail(context.getClassName(), ((TransformerHolder<?>)transformer).owner(), transformer);
                 transformers.remove(transformer);
                 continue;
             }

--- a/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
+++ b/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
@@ -121,7 +121,8 @@ public class ClassTransformer {
         finalFlags &= ~ILaunchPluginService.ComputeFlags.SIMPLE_REWRITE; //Strip any modlauncher-custom fields
 
         //Only use the TransformerClassWriter when needed as it's slower, and only COMPUTE_FRAMES calls getCommonSuperClass
-        ClassWriter cw = finalFlags == ILaunchPluginService.ComputeFlags.COMPUTE_FRAMES ? new TransformerClassWriter(this, clazz) : new ClassWriter(finalFlags | Opcodes.ASM7);
+        boolean requireFrames = (finalFlags & ILaunchPluginService.ComputeFlags.COMPUTE_FRAMES) == ILaunchPluginService.ComputeFlags.COMPUTE_FRAMES;
+        ClassWriter cw = requireFrames ? new TransformerClassWriter(this, clazz) : new ClassWriter(finalFlags | Opcodes.ASM7);
         clazz.accept(cw);
         if (MarkerManager.exists("CLASSDUMP") && LOGGER.isEnabled(Level.TRACE) && LOGGER.isEnabled(Level.TRACE, MarkerManager.getMarker("CLASSDUMP"))) {
             dumpClass(cw.toByteArray(), className);

--- a/src/main/java/cpw/mods/modlauncher/PredicateVisitor.java
+++ b/src/main/java/cpw/mods/modlauncher/PredicateVisitor.java
@@ -32,17 +32,17 @@ public class PredicateVisitor extends ClassVisitor {
     private boolean result;
 
     PredicateVisitor(final ITransformerVotingContext.FieldPredicate fieldPredicate) {
-        super(Opcodes.ASM7);
+        super(TransformerClassWriter.ASM_VERSION);
         this.fieldPredicate = fieldPredicate;
     }
 
     PredicateVisitor(final ITransformerVotingContext.MethodPredicate methodPredicate) {
-        super(Opcodes.ASM7);
+        super(TransformerClassWriter.ASM_VERSION);
         this.methodPredicate = methodPredicate;
     }
 
     PredicateVisitor(final ITransformerVotingContext.ClassPredicate classPredicate) {
-        super(Opcodes.ASM7);
+        super(TransformerClassWriter.ASM_VERSION);
         this.classPredicate = classPredicate;
     }
 

--- a/src/main/java/cpw/mods/modlauncher/TransformerClassWriter.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformerClassWriter.java
@@ -18,6 +18,7 @@
 
 package cpw.mods.modlauncher;
 
+import cpw.mods.modlauncher.serviceapi.ILaunchPluginService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.objectweb.asm.ClassReader;
@@ -34,16 +35,26 @@ import java.util.stream.Stream;
 
 class TransformerClassWriter extends ClassWriter {
     private static final Logger LOGGER = LogManager.getLogger();
+    public static final int ASM_VERSION = Opcodes.ASM7;
+    private static final int SIMPLE_REWRITE_FLAG = ILaunchPluginService.ComputeFlags.SIMPLE_REWRITE;
+    private static final int COMPUTE_FRAMES_FLAG = ILaunchPluginService.ComputeFlags.COMPUTE_FRAMES;
     private static final HashMap<String,String> classParents = new HashMap<>();
     private static final HashMap<String, Set<String>> classHierarchies = new HashMap<>();
     private static final HashMap<String, Boolean> isInterface = new HashMap<>();
     private ClassTransformer classTransformer;
-    private final ClassNode clazzAccessor;
 
-    public TransformerClassWriter(final ClassTransformer classTransformer, final ClassNode clazzAccessor) {
-        super(ClassWriter.COMPUTE_FRAMES | Opcodes.ASM7);
+    public static ClassWriter createClassWriter(final int mlFlags, final ClassTransformer classTransformer, final ClassNode clazzAccessor) {
+        int writerFlag = mlFlags & ~SIMPLE_REWRITE_FLAG; //Strip any modlauncher-custom fields
+        writerFlag |= ASM_VERSION;
+
+        //Only use the TransformerClassWriter when needed as it's slower, and only COMPUTE_FRAMES calls getCommonSuperClass
+        boolean requireFrames = (writerFlag & COMPUTE_FRAMES_FLAG) != 0;
+        return requireFrames ? new TransformerClassWriter(writerFlag, classTransformer, clazzAccessor) : new ClassWriter(mlFlags);
+    }
+
+    private TransformerClassWriter(final int writerFlags, final ClassTransformer classTransformer, final ClassNode clazzAccessor) {
+        super(writerFlags);
         this.classTransformer = classTransformer;
-        this.clazzAccessor = clazzAccessor;
         if (!classParents.containsKey(clazzAccessor.name)) {
             computeHierarchy(clazzAccessor);
         }
@@ -118,7 +129,7 @@ class TransformerClassWriter extends ClassWriter {
         private final ClassTransformer classTransformer;
 
         public SuperCollectingVisitor(final ClassTransformer classTransformer) {
-            super(Opcodes.ASM7);
+            super(ASM_VERSION);
             this.classTransformer = classTransformer;
         }
 


### PR DESCRIPTION
Computing frames can be slow, and we still need to rewrite a lot of classes at launch.
Unfortunally, this is really hard to prove with a simple JMH mircobenchmark, as it requires a complex class with frames and maxs to test on, but when testing these changes together with some adjustments in forge and accesstransformer to use the new behaviour, it got a load time reduction of around 2.5-3 seconds (from around 15.9 s to 13s, see https://gist.github.com/ichttt/98da420deabd8e904ac53fece883df16 for details).
I didn't touch EventBus yet as the ASM for it looks quite complex and I haven't had the time to dig deeper to verify what flags it needs.
