### PR TITLE
Use ConcurrentHashMaps, fixes #42

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'org.ajoberstar.reckon' version '0.12.0'
     id 'org.ajoberstar.grgit' version '4.0.0'
     id 'com.github.ben-manes.versions' version '0.27.0'
-    id 'me.champeau.gradle.jmh' version '0.5.0'
+    id 'me.champeau.gradle.jmh' version '0.5.0-rc-1' //0.5.0 is broken for us, see https://github.com/melix/jmh-gradle-plugin/issues/159
 }
 apply plugin: 'java-library'
 apply plugin: 'maven-publish'

--- a/src/main/java/cpw/mods/modlauncher/TransformerClassWriter.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformerClassWriter.java
@@ -29,14 +29,15 @@ import org.objectweb.asm.tree.ClassNode;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 class TransformerClassWriter extends ClassWriter {
     private static final Logger LOGGER = LogManager.getLogger();
-    private static final HashMap<String,String> classParents = new HashMap<>();
-    private static final HashMap<String, Set<String>> classHierarchies = new HashMap<>();
-    private static final HashMap<String, Boolean> isInterface = new HashMap<>();
+    private static final Map<String,String> classParents = new ConcurrentHashMap<>();
+    private static final Map<String, Set<String>> classHierarchies = new ConcurrentHashMap<>();
+    private static final Map<String, Boolean> isInterface = new ConcurrentHashMap<>();
     private ClassTransformer classTransformer;
     private final ClassNode clazzAccessor;
 


### PR DESCRIPTION
Microbenchmark results:
With traditional HashMap:
Benchmark                                      Mode  Cnt   Score   Error  Units
TransformBenchmark.transformDummyClass         avgt    9  10,990 ± 3,939  us/op
TransformBenchmark.transformDummyClass:·stack  avgt          NaN            ---
TransformBenchmark.transformNoop               avgt    9   4,309 ± 2,177  us/op
TransformBenchmark.transformNoop:·stack        avgt          NaN            ---

With concurrent HashMap:
Benchmark                                      Mode  Cnt   Score   Error  Units
TransformBenchmark.transformDummyClass         avgt    9  11,001 ± 3,756  us/op
TransformBenchmark.transformDummyClass:·stack  avgt          NaN            ---
TransformBenchmark.transformNoop               avgt    9   4,386 ± 2,302  us/op
TransformBenchmark.transformNoop:·stack        avgt          NaN            ---

Note that the error margin is very high, as it looks like the garbage collector is the actual bottleneck here, as my CPU was maxed out fairly often despite this being a single-threaded benchmark.

Forge startup time does not seem to change when using ConcurrentHashMaps
Note: this fix may not be complete, there is some weird stuff going on that may not be completly thread-safe