### PR TITLE
Add code to make debugging ClassNotFoundExceptions easier

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/TransformingClassLoader.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformingClassLoader.java
@@ -95,10 +95,18 @@ public class TransformingClassLoader extends ClassLoader implements ITransformin
                 LOGGER.trace(CLASSLOADING, "Attempting to load {}", name);
                 final Class<?> loadedClass = loadClass(name, this.classBytesFinder);
                 LOGGER.trace(CLASSLOADING, "Class loaded for {}", name);
+                if (resolve)
+                    resolveClass(loadedClass);
                 return loadedClass;
             } catch (ClassNotFoundException | SecurityException e) {
                 LOGGER.trace(CLASSLOADING, "Delegating to parent classloader {}", name);
-                return super.loadClass(name, resolve);
+                try {
+                    return super.loadClass(name, resolve);
+                } catch (ClassNotFoundException | SecurityException e1) {
+                    e1.addSuppressed(e);
+                    LOGGER.trace(CLASSLOADING, "Parent classloader error on {}", name, e);
+                    throw e1;
+                }
             }
         }
     }


### PR DESCRIPTION
There is currently an error floating around that has not been debugged yet (https://github.com/MinecraftForge/MinecraftForge/issues/6719)
I couldn't figure out the issue, so I added some code so the original exception will now get logged as well. I also added a call to `resolveClass` when resolve is true, which may fix the issue (not sure though), but is also required by the `loadClass` contract, although I could not observe this flag being true yet