### PR TITLE
Reduce benchmark error by a lot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,8 +100,8 @@ jmh {
     include = [ 'cpw.mods.modlauncher.benchmarks.TransformBenchmark' ]
     benchmarkMode = ['avgt' ]
     profilers = [ 'stack' ]
-    timeOnIteration = '5s'
-    warmup = '5s'
+    timeOnIteration = '3s'
+    warmup = '3s'
     warmupIterations = 3
     iterations = 3
     fork = 3


### PR DESCRIPTION
Reduce error in benchmark by clearing the AuditLog after each iteration and making iterations shorter (so less garbage can pile up, the JVM is already hot after ~2 warmup iterations of 3 seconds anyway, and we have 3 warmup iterations). Benchmark results are therefor *not* compatible with older benchmark versions