### PR TITLE
Fix Bad and Unneeded check, and remove ASM version 

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/LaunchPluginHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/LaunchPluginHandler.java
@@ -81,9 +81,6 @@ public class LaunchPluginHandler {
             LOGGER.debug(LAUNCHPLUGIN, "LauncherPluginService {} offering transform {}", iLaunchPluginService.name(), className.getClassName());
             final int pluginFlags = iLaunchPluginService.processClassWithFlags(phase, node, className, reason);
             if (pluginFlags != ILaunchPluginService.ComputeFlags.NO_REWRITE) {
-                //If simple rewrite is specified, no other flags should be present
-                if ((pluginFlags & ILaunchPluginService.ComputeFlags.SIMPLE_REWRITE) != 0 && pluginFlags != ILaunchPluginService.ComputeFlags.SIMPLE_REWRITE)
-                    throw new RuntimeException(String.format("LauncherPluginService %s returned SIMPLE_REWRITE and additional flags (%s) while transforming %s", iLaunchPluginService.name(), flags, className.getClassName()));
                 auditTrail.addPluginAuditTrail(className.getClassName(), iLaunchPluginService, phase);
                 LOGGER.debug(LAUNCHPLUGIN, "LauncherPluginService {} transformed {} with class compute flags {}", iLaunchPluginService.name(), className.getClassName(), pluginFlags);
                 flags |= pluginFlags;

--- a/src/main/java/cpw/mods/modlauncher/TransformerClassWriter.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformerClassWriter.java
@@ -42,11 +42,10 @@ class TransformerClassWriter extends ClassWriter {
     private ClassTransformer classTransformer;
 
     public static ClassWriter createClassWriter(final int mlFlags, final ClassTransformer classTransformer, final ClassNode clazzAccessor) {
-        int writerFlag = mlFlags & ~ILaunchPluginService.ComputeFlags.SIMPLE_REWRITE; //Strip any modlauncher-custom fields
-        writerFlag |= Opcodes.ASM7;
+        final int writerFlag = mlFlags & ~ILaunchPluginService.ComputeFlags.SIMPLE_REWRITE; //Strip any modlauncher-custom fields
 
         //Only use the TransformerClassWriter when needed as it's slower, and only COMPUTE_FRAMES calls getCommonSuperClass
-        return (writerFlag & ILaunchPluginService.ComputeFlags.COMPUTE_FRAMES) != 0 ? new TransformerClassWriter(writerFlag, classTransformer, clazzAccessor) : new ClassWriter(mlFlags);
+        return (writerFlag & ILaunchPluginService.ComputeFlags.COMPUTE_FRAMES) != 0 ? new TransformerClassWriter(writerFlag, classTransformer, clazzAccessor) : new ClassWriter(writerFlag);
     }
 
     private TransformerClassWriter(final int writerFlags, final ClassTransformer classTransformer, final ClassNode clazzAccessor) {


### PR DESCRIPTION
- Remove bad and unneeded check. There are cases (as EventBus) where it makes sense to use SIMPLE_REWRITE with other flags, and the code can handle it just fine.
- Fix ClassWriter flags (the normal classwriter did get the wrong flags, and the ClassWriter flags should *not* contain the ASM version, as the only valid flags are the ClassWriter flags)