### PR TITLE
Fix the pre-class transformation type

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/TransformStore.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformStore.java
@@ -37,10 +37,8 @@ public class TransformStore {
 
     public TransformStore() {
         transformers = new EnumMap<>(TransformTargetLabel.LabelType.class);
-        transformers.put(TransformTargetLabel.LabelType.CLASS, new TransformList<>(ClassNode.class));
-        transformers.put(TransformTargetLabel.LabelType.METHOD, new TransformList<>(MethodNode.class));
-        transformers.put(TransformTargetLabel.LabelType.FIELD, new TransformList<>(FieldNode.class));
-        transformers.put(TransformTargetLabel.LabelType.PRE_CLASS, new TransformList<>(ClassNode.class));
+        for (TransformTargetLabel.LabelType type : TransformTargetLabel.LabelType.values())
+            transformers.put(type, new TransformList<>(type.getNodeType()));
     }
 
     List<ITransformer<FieldNode>> getTransformersFor(String className, FieldNode field) {
@@ -56,7 +54,7 @@ public class TransformStore {
     }
 
     List<ITransformer<ClassNode>> getTransformersFor(String className, TransformTargetLabel.LabelType classType) {
-        TransformTargetLabel tl = new TransformTargetLabel(className);
+        TransformTargetLabel tl = new TransformTargetLabel(className, classType);
         TransformList<ClassNode> transformerlist = classType.getFromMap(this.transformers);
         return transformerlist.getTransformersForLabel(tl);
     }

--- a/src/main/java/cpw/mods/modlauncher/TransformationServiceDecorator.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformationServiceDecorator.java
@@ -87,13 +87,16 @@ public class TransformationServiceDecorator {
                 }
         ));
         for (Type type : transformersByType.keySet()) {
-            final TransformTargetLabel.LabelType labelType = TransformTargetLabel.LabelType.getTypeFor(type).orElseThrow(() -> new IllegalArgumentException("Invalid transformer type found"));
+            final List<TransformTargetLabel.LabelType> labelTypes = TransformTargetLabel.LabelType.getTypeFor(type);
+            if (labelTypes.isEmpty()) {
+                throw new IllegalArgumentException("Invalid transformer type found");
+            }
             for (ITransformer<?> xform : transformersByType.get(type)) {
                 final Set<ITransformer.Target> targets = xform.targets();
                 if (targets.isEmpty()) continue;
                 final Map<TransformTargetLabel.LabelType, List<TransformTargetLabel>> labelTypeListMap = targets.stream().map(TransformTargetLabel::new).collect(Collectors.groupingBy(TransformTargetLabel::getLabelType));
-                if (labelTypeListMap.keySet().size() > 1 || !labelTypeListMap.keySet().contains(labelType)) {
-                    LOGGER.error(MODLAUNCHER,"Invalid target {} for transformer {}", labelType, xform);
+                if (labelTypeListMap.keySet().size() > 1 || labelTypes.stream().noneMatch(labelTypeListMap::containsKey)) {
+                    LOGGER.error(MODLAUNCHER,"Invalid target {} for transformer {}", labelTypes, xform);
                     throw new IllegalArgumentException("The transformer contains invalid targets");
                 }
                 labelTypeListMap.values().stream().flatMap(Collection::stream).forEach(target -> transformStore.addTransformer(target, xform, service));


### PR DESCRIPTION
Currently, you can't use pre-class, as several places are not laid out for it yet.
See this error: https://github.com/cpw/modlauncher/issues/37#issuecomment-679100887
There is two instances remaining that class the now deprecated `TransformTargetLabel` contructor, however both of them will be removed by PR #52