### PR TITLE
WIP: Fixes and hack-removal for JDK 16

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/SecureJarHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/SecureJarHandler.java
@@ -18,15 +18,10 @@
 
 package cpw.mods.modlauncher;
 
-import cpw.mods.modlauncher.api.IEnvironment;
-import cpw.mods.modlauncher.api.LamdbaExceptionUtils;
-import org.apache.logging.log4j.LogManager;
-import sun.security.util.ManifestEntryVerifier;
+import cpw.mods.modlauncher.api.JarEntryWithManifest;
 
 import javax.annotation.Nullable;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+
 import java.net.URL;
 import java.security.*;
 import java.util.HashMap;
@@ -34,56 +29,17 @@ import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.Manifest;
 
-import static cpw.mods.modlauncher.LogMarkers.CLASSLOADING;
-
 public class SecureJarHandler {
-    private static final Class<?> JVCLASS = LamdbaExceptionUtils.uncheck(()->Class.forName("java.util.jar.JarVerifier"));
-    private static final Method BEGIN_ENTRY = LamdbaExceptionUtils.uncheck(()->JVCLASS.getMethod("beginEntry", JarEntry.class, ManifestEntryVerifier.class));
-    private static final Method UPDATE = LamdbaExceptionUtils.uncheck(()->JVCLASS.getMethod("update", int.class, byte[].class, int.class, int.class, ManifestEntryVerifier.class));
-    private static final Field JV;
-    static {
-        Field jv;
-        try {
-            jv = Manifest.class.getDeclaredField("jv");
-            jv.setAccessible(true);
-            BEGIN_ENTRY.setAccessible(true);
-            UPDATE.setAccessible(true);
-        } catch (NoSuchFieldException e) {
-            LogManager.getLogger().warn("LEGACY JDK DETECTED, SECURED JAR HANDLING DISABLED");
-            jv = null;
-        }
-        JV = jv;
-    }
 
-
-    @SuppressWarnings("ConstantConditions")
-    // Manifest is required to originate from an ensureInitialized JarFile. Otherwise it will not work
-    public static CodeSource createCodeSource(final String name, @Nullable final URL url, final byte[] bytes, @Nullable final Manifest manifest) {
-        if (JV == null) return null;
-        if (manifest == null) return null;
+    // Manifest is required to originate from a read JarEntry, otherwise it will not work
+    // in our case the JarEntry will always be read fully before coming here, so getCodeSigners will be not null, if there are any
+    public static CodeSource createCodeSource(@Nullable final URL url, @Nullable final JarEntryWithManifest entryWithManifest) {
+        if (entryWithManifest == null) return null;
         if (url == null) return null;
-        JarEntry je = new JarEntry(name);
-        ManifestEntryVerifier mev = new ManifestEntryVerifier(manifest);
-        Object obj = LamdbaExceptionUtils.uncheck(()->JV.get(manifest));
-        if (obj == null) {
-            // we don't have a fully fledged manifest with security info, for some reason (likely loaded by default JAR code, rather than our stuff)
-            return null;
-        }
-        // begin Entry on JarVerifier
-        LamdbaExceptionUtils.uncheck(()->BEGIN_ENTRY.invoke(obj, je, mev));
-        // Feed the bytes to the underlying MEV
-        LamdbaExceptionUtils.uncheck(()->UPDATE.invoke(obj, bytes.length, bytes, 0, bytes.length, mev));
-        // Generate the cert check - signers will be loaded into the dummy jar entry
-        try {
-            UPDATE.invoke(obj, -1, bytes, 0, bytes.length, mev);
-        } catch (SecurityException se) {
-            // SKIP security exception - we didn't validate the signature for some reason
-            LogManager.getLogger().info(CLASSLOADING, "Validation problem during class loading of {}", name, se);
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException(e);
-        }
-        CodeSigner[] signers = je.getCodeSigners();
-        return new CodeSource(url, signers);
+        JarEntry je = entryWithManifest.getJarEntry();
+        Manifest manifest = entryWithManifest.getManifest();
+        if (je == null || manifest == null) return null;
+        return new CodeSource(url, je.getCodeSigners());
     }
 
     private static final Map<CodeSource, ProtectionDomain> pdCache = new HashMap<>();
@@ -98,6 +54,6 @@ public class SecureJarHandler {
     }
 
     public static boolean canHandleSecuredJars() {
-        return JV != null;
+        return true;
     }
 }

--- a/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
@@ -136,7 +136,7 @@ class TransformationServicesHandler {
         final ServiceLoader<ITransformerDiscoveryService> discoveryServices = errorHandlingServiceLoader(ITransformerDiscoveryService.class, serviceConfigurationError -> LOGGER.fatal(MODLAUNCHER, "Encountered serious error loading transformation discoverer, expect problems", serviceConfigurationError));
         final List<Path> additionalPaths = map(discoveryServices, s -> s.candidates(gameDir)).flatMap(Collection::stream).collect(Collectors.toList());
         LOGGER.debug(MODLAUNCHER, "Found additional transformation services from discovery services: {}", additionalPaths);
-        TransformerClassLoader cl = new TransformerClassLoader(Java9ClassLoaderUtil.getSystemClassPathURLs());
+        TransformerClassLoader cl = new TransformerClassLoader(TransformationServicesHandler.class.getClassLoader());
         additionalPaths.stream().map(LamdbaExceptionUtils.rethrowFunction(p->p.toUri().toURL())).forEach(cl::addURL);
         transformationServices = ServiceLoaderStreamUtils.errorHandlingServiceLoader(ITransformationService.class, cl, serviceConfigurationError -> LOGGER.fatal(MODLAUNCHER, "Encountered serious error loading transformation service, expect problems", serviceConfigurationError));
         serviceLookup = ServiceLoaderStreamUtils.toMap(transformationServices, ITransformationService::name, TransformationServiceDecorator::new);
@@ -155,8 +155,8 @@ class TransformationServicesHandler {
 
 
     private static class TransformerClassLoader extends URLClassLoader {
-        TransformerClassLoader(final URL[] urls) {
-            super(urls);
+        TransformerClassLoader(final ClassLoader parent) {
+            super(new URL[0], parent);
         }
 
         @Override

--- a/src/main/java/cpw/mods/modlauncher/TransformingClassLoaderBuilder.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformingClassLoaderBuilder.java
@@ -27,18 +27,19 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.jar.Manifest;
 
+import cpw.mods.modlauncher.api.JarEntryWithManifest;
 import static cpw.mods.modlauncher.api.LamdbaExceptionUtils.rethrowFunction;
 
 class TransformingClassLoaderBuilder implements ITransformingClassLoaderBuilder {
     private final List<Path> transformationPaths = new ArrayList<>();
     private Function<String, Enumeration<URL>> resourcesLocator;
-    private Function<URLConnection, Optional<Manifest>> manifestLocator;
+    private Function<URLConnection, Optional<JarEntryWithManifest>> manifestLocator;
 
     URL[] getSpecialJarsAsURLs() {
         return transformationPaths.stream().map(rethrowFunction(path->path.toUri().toURL())).toArray(URL[]::new);
     }
 
-    Function<URLConnection, Optional<Manifest>> getManifestLocator() {
+    Function<URLConnection, Optional<JarEntryWithManifest>> getManifestLocator() {
         return manifestLocator;
     }
 
@@ -59,6 +60,10 @@ class TransformingClassLoaderBuilder implements ITransformingClassLoaderBuilder 
 
     @Override
     public void setManifestLocator(final Function<URLConnection, Optional<Manifest>> manifestLocator) {
+    }
+
+    @Override
+    public void setManifestAndJarLocator(Function<URLConnection, Optional<JarEntryWithManifest>> manifestLocator) {
         this.manifestLocator = manifestLocator;
     }
 

--- a/src/main/java/cpw/mods/modlauncher/api/ITransformingClassLoaderBuilder.java
+++ b/src/main/java/cpw/mods/modlauncher/api/ITransformingClassLoaderBuilder.java
@@ -33,5 +33,11 @@ public interface ITransformingClassLoaderBuilder {
 
     void setResourceEnumeratorLocator(Function<String, Enumeration<URL>> resourceEnumeratorLocator);
 
-    void setManifestLocator(Function<URLConnection, Optional<Manifest>> manifestLocator);
+    @Deprecated
+    default void setManifestLocator(Function<URLConnection, Optional<Manifest>> manifestLocator) {
+
+    }
+
+    void setManifestAndJarLocator(Function<URLConnection, Optional<JarEntryWithManifest>> manifestLocator);
+
 }

--- a/src/main/java/cpw/mods/modlauncher/api/JarEntryWithManifest.java
+++ b/src/main/java/cpw/mods/modlauncher/api/JarEntryWithManifest.java
@@ -1,0 +1,23 @@
+package cpw.mods.modlauncher.api;
+
+import java.util.jar.JarEntry;
+import java.util.jar.Manifest;
+
+public final class JarEntryWithManifest {
+
+    private final JarEntry jarEntry;
+    private final Manifest manifest;
+
+    public JarEntryWithManifest(JarEntry jarEntry, Manifest manifest) {
+        this.jarEntry = jarEntry;
+        this.manifest = manifest;
+    }
+
+    public JarEntry getJarEntry() {
+        return jarEntry;
+    }
+
+    public Manifest getManifest() {
+        return manifest;
+    }
+}


### PR DESCRIPTION
Coincidentally should also make Jar verification work on older JDKs.
"grossjava9hacks" is also no longer needed, but it looks like mixin uses it, so it needs to stay in and be deprecated first.

Fixes https://github.com/cpw/modlauncher/issues/65.